### PR TITLE
onStatusChange and hasConnection varibales have null safety property

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -5,7 +5,7 @@ import 'package:build/internet_connection_checker.dart';
 Future<void> main() async {
   // Simple check to see if we have Internet
   print('The statement \'this machine is connected to the Internet\' is: ');
-  final bool isConnected = await InternetConnectionChecker().hasConnection;
+  final bool isConnected = await InternetConnectionChecker().hasConnection!;
   print(
     isConnected.toString(),
   );
@@ -23,7 +23,7 @@ Future<void> main() async {
 
   // actively listen for status updates
   StreamSubscription<InternetConnectionStatus> listener =
-      InternetConnectionChecker().onStatusChange.listen(
+      InternetConnectionChecker().onStatusChange!.listen(
     (InternetConnectionStatus status) {
       switch (status) {
         case InternetConnectionStatus.connected:

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:build/internet_connection_checker.dart';
+import 'package:shitty_connection_checker/internet_connection_checker.dart';
 
 Future<void> main() async {
   // Simple check to see if we have Internet

--- a/lib/internet_connection.dart
+++ b/lib/internet_connection.dart
@@ -147,7 +147,7 @@ class InternetConnectionChecker {
   /// If at least one of the addresses is reachable
   /// we assume an internet connection is available and return `true`.
   /// `false` otherwise.
-  Future<bool> get hasConnection async {
+  Future<bool>? get hasConnection async {
     List<Future<AddressCheckResult>> requests = <Future<AddressCheckResult>>[];
 
     for (AddressCheckOptions addressOptions in addresses) {
@@ -181,7 +181,7 @@ class InternetConnectionChecker {
   /// [InternetConnectionStatus.connected].
   /// [InternetConnectionStatus.disconnected] otherwise.
   Future<InternetConnectionStatus> get connectionStatus async {
-    return await hasConnection
+    return await hasConnection!
         ? InternetConnectionStatus.connected
         : InternetConnectionStatus.disconnected;
   }
@@ -284,7 +284,7 @@ class InternetConnectionChecker {
   ///
   /// When all the listeners are removed from `onStatusChange`, the internal
   /// timer is cancelled and the stream does not emit events.
-  Stream<InternetConnectionStatus> get onStatusChange =>
+  Stream<InternetConnectionStatus>? get onStatusChange =>
       _statusController.stream;
 
   /// Returns true if there are any listeners attached to [onStatusChange]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: build
 description: A pure Dart library that checks for internet by opening a socket to
   a list of specified addresses, each with individual port and timeout. Defaults
   are provided for convenience.
-version: 0.0.1
+version: 0.0.2
 repository: https://github.com/RounakTadvi/internet_connection_checker
 homepage: https://github.com/RounakTadvi/internet_connection_checker/tree/main
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: build
+name: shitty_connection_checker
 description: A pure Dart library that checks for internet by opening a socket to
   a list of specified addresses, each with individual port and timeout. Defaults
   are provided for convenience.

--- a/test/address_check_options_test.dart
+++ b/test/address_check_options_test.dart
@@ -1,4 +1,4 @@
-import 'package:build/internet_connection_checker.dart';
+import 'package:shitty_connection_checker/internet_connection_checker.dart';
 import 'package:test/test.dart';
 import 'package:universal_io/io.dart';
 

--- a/test/address_check_result_test.dart
+++ b/test/address_check_result_test.dart
@@ -1,4 +1,4 @@
-import 'package:build/internet_connection_checker.dart';
+import 'package:shitty_connection_checker/internet_connection_checker.dart';
 import 'package:test/test.dart';
 import 'package:universal_io/io.dart';
 

--- a/test/internet_connection_checker_test.dart
+++ b/test/internet_connection_checker_test.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:build/internet_connection_checker.dart';
+import 'package:shitty_connection_checker/internet_connection_checker.dart';
 import 'package:test/test.dart';
 
 void main() async {

--- a/test/internet_connection_checker_test.dart
+++ b/test/internet_connection_checker_test.dart
@@ -77,7 +77,7 @@ void main() async {
     });
 
     test('''We should have listeners 1''', () {
-      listener1 = InternetConnectionChecker().onStatusChange.listen((_) {});
+      listener1 = InternetConnectionChecker().onStatusChange!.listen((_) {});
       expect(
         InternetConnectionChecker().hasListeners,
         isTrue,
@@ -85,8 +85,8 @@ void main() async {
     });
 
     test('''We should have listeners 2''', () {
-      listener1 = InternetConnectionChecker().onStatusChange.listen((_) {});
-      listener2 = InternetConnectionChecker().onStatusChange.listen((_) {});
+      listener1 = InternetConnectionChecker().onStatusChange!.listen((_) {});
+      listener2 = InternetConnectionChecker().onStatusChange!.listen((_) {});
       expect(
         InternetConnectionChecker().hasListeners,
         isTrue,
@@ -94,9 +94,9 @@ void main() async {
     });
 
     test('''We should have listeners 3''', () async {
-      listener1 = InternetConnectionChecker().onStatusChange.listen((_) {});
+      listener1 = InternetConnectionChecker().onStatusChange!.listen((_) {});
       await listener1!.cancel();
-      listener2 = InternetConnectionChecker().onStatusChange.listen((_) {});
+      listener2 = InternetConnectionChecker().onStatusChange!.listen((_) {});
       expect(
         InternetConnectionChecker().hasListeners,
         isTrue,
@@ -104,9 +104,9 @@ void main() async {
     });
 
     test('''We shouldn't have any listeners 2''', () async {
-      listener1 = InternetConnectionChecker().onStatusChange.listen((_) {});
+      listener1 = InternetConnectionChecker().onStatusChange!.listen((_) {});
       await listener1!.cancel();
-      listener2 = InternetConnectionChecker().onStatusChange.listen((_) {});
+      listener2 = InternetConnectionChecker().onStatusChange!.listen((_) {});
       await listener2!.cancel();
       expect(
         InternetConnectionChecker().hasListeners,
@@ -122,7 +122,7 @@ void main() async {
     });
 
     test('''We should have listeners 1 [isActivelyChecking]''', () {
-      listener1 = InternetConnectionChecker().onStatusChange.listen((_) {});
+      listener1 = InternetConnectionChecker().onStatusChange!.listen((_) {});
       expect(
         InternetConnectionChecker().isActivelyChecking,
         isTrue,
@@ -130,8 +130,8 @@ void main() async {
     });
 
     test('''We should have listeners 2 [isActivelyChecking]''', () {
-      listener1 = InternetConnectionChecker().onStatusChange.listen((_) {});
-      listener2 = InternetConnectionChecker().onStatusChange.listen((_) {});
+      listener1 = InternetConnectionChecker().onStatusChange!.listen((_) {});
+      listener2 = InternetConnectionChecker().onStatusChange!.listen((_) {});
       expect(
         InternetConnectionChecker().isActivelyChecking,
         isTrue,
@@ -139,9 +139,9 @@ void main() async {
     });
 
     test('''We should have listeners 3 [isActivelyChecking]''', () async {
-      listener1 = InternetConnectionChecker().onStatusChange.listen((_) {});
+      listener1 = InternetConnectionChecker().onStatusChange!.listen((_) {});
       await listener1!.cancel();
-      listener2 = InternetConnectionChecker().onStatusChange.listen((_) {});
+      listener2 = InternetConnectionChecker().onStatusChange!.listen((_) {});
       expect(
         InternetConnectionChecker().isActivelyChecking,
         isTrue,
@@ -150,9 +150,9 @@ void main() async {
 
     test('''We shouldn't have any listeners 2 [isActivelyChecking]''',
         () async {
-      listener1 = InternetConnectionChecker().onStatusChange.listen((_) {});
+      listener1 = InternetConnectionChecker().onStatusChange!.listen((_) {});
       await listener1!.cancel();
-      listener2 = InternetConnectionChecker().onStatusChange.listen((_) {});
+      listener2 = InternetConnectionChecker().onStatusChange!.listen((_) {});
       await listener2!.cancel();
       expect(
         InternetConnectionChecker().isActivelyChecking,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

The cause of theses changes is this Unit test scenario : 

`
class MockDataConnectionChecker extends Mock
    implements InternetConnectionChecker {}
main() {
  NetworkInfoImpl? networkInfoImpl;
  MockDataConnectionChecker? mockDataConnectionChecker;
  setUp(() {
    mockDataConnectionChecker = MockDataConnectionChecker();
    networkInfoImpl =
        NetworkInfoImpl(dataConnectionChecker: mockDataConnectionChecker!);
  });
  test('return device connected to network', () async {
    when(mockDataConnectionChecker!.onStatusChange).thenAnswer(
        (_) => (Stream.fromIterable([InternetConnectionStatus.connected])));
    networkInfoImpl!.isConnected.listen(
      expectAsync1((event) {
        expect(event, true);
      }),
    );
  });
  test('return device has connection', () async {
    when(mockDataConnectionChecker!.hasConnection)
        .thenAnswer((_) async => true);
    final result = await networkInfoImpl!.hasConnection;
    expect(result, true);
  });
}
`