### PR TITLE
Chore: Update connectionStatus' doc comment

### DIFF
--- a/lib/internet_connection.dart
+++ b/lib/internet_connection.dart
@@ -164,7 +164,7 @@ class InternetConnectionChecker {
 
   /// Initiates a request to each address in [addresses].
   /// If at least one of the addresses is reachable
-  /// we assume an internet connection is available and return `true`
+  /// we assume an internet connection is available and return
   /// [InternetConnectionStatus.connected].
   /// [InternetConnectionStatus.disconnected] otherwise.
   Future<InternetConnectionStatus> get connectionStatus async {


### PR DESCRIPTION
Remove `true`, since it doesn't return a `bool`.

## Status

**READY**

## Breaking Changes

NO

## Description

Remove `true` from doc comment of `connectionStatus` method, since it doesn't return a `bool`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [x] 🗑️ Chore