### PR TITLE
Fixes #12 and Fixes #14

### DIFF
--- a/lib/internet_connection.dart
+++ b/lib/internet_connection.dart
@@ -76,6 +76,14 @@ class InternetConnectionChecker {
       ),
       AddressCheckOptions(
         InternetAddress(
+          '2606:4700:4700::1111', // CloudFlare
+          type: InternetAddressType.IPv6,
+        ),
+        port: DEFAULT_PORT,
+        timeout: DEFAULT_TIMEOUT,
+      ),
+      AddressCheckOptions(
+        InternetAddress(
           '8.8.4.4', // Google
           type: InternetAddressType.IPv4,
         ),
@@ -84,8 +92,24 @@ class InternetConnectionChecker {
       ),
       AddressCheckOptions(
         InternetAddress(
+          '2001:4860:4860::8888', // Google
+          type: InternetAddressType.IPv6,
+        ),
+        port: DEFAULT_PORT,
+        timeout: DEFAULT_TIMEOUT,
+      ),
+      AddressCheckOptions(
+        InternetAddress(
           '208.67.222.222', // OpenDNS
           type: InternetAddressType.IPv4,
+        ), // OpenDNS
+        port: DEFAULT_PORT,
+        timeout: DEFAULT_TIMEOUT,
+      ),
+      AddressCheckOptions(
+        InternetAddress(
+          '2620:0:ccc::2', // OpenDNS
+          type: InternetAddressType.IPv6,
         ), // OpenDNS
         port: DEFAULT_PORT,
         timeout: DEFAULT_TIMEOUT,

--- a/lib/internet_connection.dart
+++ b/lib/internet_connection.dart
@@ -145,7 +145,7 @@ class InternetConnectionChecker {
     int length = addresses.length;
 
     for (AddressCheckOptions addressOptions in addresses) {
-      await isHostReachable(addressOptions).then(
+      isHostReachable(addressOptions).then(
         (AddressCheckResult request) {
           length -= 1;
           if (!result.isCompleted) {


### PR DESCRIPTION
Trying to end the test immediately when any of the pings succeed

## Status

**READY**

## Breaking Changes

NO

## Description

This turned out to be a one keyword change, removing an `await` so far. I have 6 AWS EC2 IP address for connection test in my app, and some of them started to act up. This caused me 10 seconds default delay. By removing the await there's no more wait. I tried to test the counter case: I put my phone into airplane mode and then the data check determines no connection. So it seems I'm not breaking any functionality.
The IPv6 address addition is based on https://github.com/komapeb/data_connection_checker/issues/13#issuecomment-732534075.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore