### PR TITLE
Ability to provide a host name instead of IP address

### DIFF
--- a/lib/address_check_options.dart
+++ b/lib/address_check_options.dart
@@ -8,11 +8,15 @@ part of internet_connection_checker;
 /// Also... yeah, I'm not great at naming things.
 class AddressCheckOptions {
   /// [AddressCheckOptions] Constructor
-  AddressCheckOptions(
-    this.address, {
+  AddressCheckOptions({
+    this.address,
+    this.hostname,
     this.port = InternetConnectionChecker.DEFAULT_PORT,
     this.timeout = InternetConnectionChecker.DEFAULT_TIMEOUT,
-  });
+  }) : assert(
+    (address != null || hostname != null) && ((address != null) != (hostname != null)),
+    'Either address or hostname must be provided, but not both.',
+  );
 
   /// An internet address or a Unix domain address.
   /// This object holds an internet address. If this internet address
@@ -21,7 +25,16 @@ class AddressCheckOptions {
   /// An Internet address combined with a port number represents an
   /// endpoint to which a socket can connect or a listening socket can
   /// bind.
-  final InternetAddress address;
+  /// Either [address] or [hostname] must not be null.
+  final InternetAddress? address;
+
+  /// The hostname to use for this connection checker.
+  /// Will be used to resolve an IP address to open the socket connection to.
+  /// Can be used to verify against services that are not guaranteed to have
+  /// a fixed IP address. Connecting via hostname also verifies that
+  /// DNS resolution is working for the client.
+  /// Either [address] or [hostname] must not be null.
+  final String? hostname;
 
   /// Port
   final int port;

--- a/lib/internet_connection.dart
+++ b/lib/internet_connection.dart
@@ -19,7 +19,8 @@ class InternetConnectionChecker {
         DEFAULT_ADDRESSES
             .map(
               (AddressCheckOptions e) => AddressCheckOptions(
-                e.address,
+                address: e.address,
+                hostname: e.hostname,
                 port: e.port,
                 timeout: checkTimeout,
               ),
@@ -86,37 +87,37 @@ class InternetConnectionChecker {
       List<AddressCheckOptions>.unmodifiable(
     <AddressCheckOptions>[
       AddressCheckOptions(
-        InternetAddress(
+        address: InternetAddress(
           '1.1.1.1', // CloudFlare
           type: InternetAddressType.IPv4,
         ),
       ),
       AddressCheckOptions(
-        InternetAddress(
+        address: InternetAddress(
           '2606:4700:4700::1111', // CloudFlare
           type: InternetAddressType.IPv6,
         ),
       ),
       AddressCheckOptions(
-        InternetAddress(
+        address: InternetAddress(
           '8.8.4.4', // Google
           type: InternetAddressType.IPv4,
         ),
       ),
       AddressCheckOptions(
-        InternetAddress(
+        address: InternetAddress(
           '2001:4860:4860::8888', // Google
           type: InternetAddressType.IPv6,
         ),
       ),
       AddressCheckOptions(
-        InternetAddress(
+        address: InternetAddress(
           '208.67.222.222', // OpenDNS
           type: InternetAddressType.IPv4,
         ), // OpenDNS
       ),
       AddressCheckOptions(
-        InternetAddress(
+        address: InternetAddress(
           '2620:0:ccc::2', // OpenDNS
           type: InternetAddressType.IPv6,
         ), // OpenDNS
@@ -156,7 +157,9 @@ class InternetConnectionChecker {
     Socket? sock;
     try {
       sock = await Socket.connect(
-        options.address,
+        // If address is null, the [AddressCheckOptions] constructor will have
+        // asserted that hostname must not be null.
+        options.address ?? (await InternetAddress.lookup(options.hostname!)),
         options.port,
         timeout: options.timeout,
       )

--- a/lib/internet_connection.dart
+++ b/lib/internet_connection.dart
@@ -141,10 +141,6 @@ class InternetConnectionChecker {
   /// See [AddressCheckOptions] for more info.
   List<AddressCheckOptions> get addresses => _addresses;
 
-  /// A callback to print debug messages
-  /// TODO: I should remove this if I make a PR
-  void Function(String)? log;
-
   set addresses(List<AddressCheckOptions> value) {
     _addresses = List<AddressCheckOptions>.unmodifiable(value);
     _maybeEmitStatusUpdate();
@@ -158,7 +154,6 @@ class InternetConnectionChecker {
   Future<AddressCheckResult> isHostReachable(
     AddressCheckOptions options,
   ) async {
-    log?.call('[ICC] Testing reachability to ${options.address ?? options.hostname}');
     Socket? sock;
     try {
       sock = await Socket.connect(
@@ -169,13 +164,11 @@ class InternetConnectionChecker {
         timeout: options.timeout,
       )
       ..destroy();
-      log?.call('[ICC] Did connect to ${options.address ?? options.hostname}');
       return AddressCheckResult(
         options,
         isSuccess: true,
       );
     } catch (e) {
-      log?.call('[ICC] Could not connect to ${options.address ?? options.hostname}: $e');
       sock?.destroy();
       return AddressCheckResult(
         options,
@@ -191,7 +184,6 @@ class InternetConnectionChecker {
   Future<bool> get hasConnection async {
     final Completer<bool> result = Completer<bool>();
     int length = addresses.length;
-    log?.call('[ICC] Initiated hasConnection for $length targets');
 
     for (final AddressCheckOptions addressOptions in addresses) {
       // ignore: unawaited_futures
@@ -245,7 +237,6 @@ class InternetConnectionChecker {
   Future<void> _maybeEmitStatusUpdate([
     Timer? timer,
   ]) async {
-    log?.call('[ICC] _maybeEmitStatusUpdate');
     // just in case
     _timerHandle?.cancel();
     timer?.cancel();

--- a/lib/internet_connection.dart
+++ b/lib/internet_connection.dart
@@ -159,7 +159,7 @@ class InternetConnectionChecker {
       sock = await Socket.connect(
         // If address is null, the [AddressCheckOptions] constructor will have
         // asserted that hostname must not be null.
-        options.address ?? (await InternetAddress.lookup(options.hostname!)),
+        options.address ?? options.hostname,
         options.port,
         timeout: options.timeout,
       )

--- a/lib/internet_connection.dart
+++ b/lib/internet_connection.dart
@@ -141,6 +141,10 @@ class InternetConnectionChecker {
   /// See [AddressCheckOptions] for more info.
   List<AddressCheckOptions> get addresses => _addresses;
 
+  /// A callback to print debug messages
+  /// TODO: I should remove this if I make a PR
+  void Function(String)? log;
+
   set addresses(List<AddressCheckOptions> value) {
     _addresses = List<AddressCheckOptions>.unmodifiable(value);
     _maybeEmitStatusUpdate();
@@ -154,6 +158,7 @@ class InternetConnectionChecker {
   Future<AddressCheckResult> isHostReachable(
     AddressCheckOptions options,
   ) async {
+    log?.call('[ICC] Testing reachability to ${options.address ?? options.hostname}');
     Socket? sock;
     try {
       sock = await Socket.connect(
@@ -164,13 +169,13 @@ class InternetConnectionChecker {
         timeout: options.timeout,
       )
       ..destroy();
-      print('[ICC] Did connect to ${options.address ?? options.hostname}');
+      log?.call('[ICC] Did connect to ${options.address ?? options.hostname}');
       return AddressCheckResult(
         options,
         isSuccess: true,
       );
     } catch (e) {
-      print('[ICC] Could not connect to ${options.address ?? options.hostname}: $e');
+      log?.call('[ICC] Could not connect to ${options.address ?? options.hostname}: $e');
       sock?.destroy();
       return AddressCheckResult(
         options,
@@ -186,6 +191,7 @@ class InternetConnectionChecker {
   Future<bool> get hasConnection async {
     final Completer<bool> result = Completer<bool>();
     int length = addresses.length;
+    log?.call('[ICC] Initiated hasConnection for $length targets');
 
     for (final AddressCheckOptions addressOptions in addresses) {
       // ignore: unawaited_futures
@@ -239,6 +245,7 @@ class InternetConnectionChecker {
   Future<void> _maybeEmitStatusUpdate([
     Timer? timer,
   ]) async {
+    log?.call('[ICC] _maybeEmitStatusUpdate');
     // just in case
     _timerHandle?.cancel();
     timer?.cancel();

--- a/lib/internet_connection.dart
+++ b/lib/internet_connection.dart
@@ -163,12 +163,14 @@ class InternetConnectionChecker {
         options.port,
         timeout: options.timeout,
       )
-        ..destroy();
+      ..destroy();
+      print('[ICC] Did connect to ${options.address ?? options.hostname}');
       return AddressCheckResult(
         options,
         isSuccess: true,
       );
     } catch (e) {
+      print('[ICC] Could not connect to ${options.address ?? options.hostname}: $e');
       sock?.destroy();
       return AddressCheckResult(
         options,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: internet_connection_checker
 description: A pure Dart library that checks for internet by opening a socket to
   a list of specified addresses, each with individual port and timeout. Defaults
   are provided for convenience.
-version: 0.0.1+7
+version: 1.0.0+5
 repository: https://github.com/RounakTadvi/internet_connection_checker
 homepage: https://github.com/RounakTadvi/internet_connection_checker/tree/main
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: internet_connection_checker
 description: A pure Dart library that checks for internet by opening a socket to
   a list of specified addresses, each with individual port and timeout. Defaults
   are provided for convenience.
-version: 0.0.1+6
+version: 0.0.1+7
 repository: https://github.com/RounakTadvi/internet_connection_checker
 homepage: https://github.com/RounakTadvi/internet_connection_checker/tree/main
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: internet_connection_checker
 description: A pure Dart library that checks for internet by opening a socket to
   a list of specified addresses, each with individual port and timeout. Defaults
   are provided for convenience.
-version: 0.0.1+5
+version: 0.0.1+6
 repository: https://github.com/RounakTadvi/internet_connection_checker
 homepage: https://github.com/RounakTadvi/internet_connection_checker/tree/main
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: internet_connection_checker
 description: A pure Dart library that checks for internet by opening a socket to
   a list of specified addresses, each with individual port and timeout. Defaults
   are provided for convenience.
-version: 0.0.1+4
+version: 0.0.1+5
 repository: https://github.com/RounakTadvi/internet_connection_checker
 homepage: https://github.com/RounakTadvi/internet_connection_checker/tree/main
 

--- a/test/address_check_options_test.dart
+++ b/test/address_check_options_test.dart
@@ -12,7 +12,7 @@ void main() {
       const int DEFAULT_PORT = 43;
       const Duration DEFAULT_TIMEOUT = Duration(seconds: 10);
       final AddressCheckOptions tOptions = AddressCheckOptions(
-        tInternetAddress,
+        address: tInternetAddress,
         port: DEFAULT_PORT,
       );
       // Action - Act
@@ -23,5 +23,52 @@ void main() {
         'AddressCheckOptions($tInternetAddress, $DEFAULT_PORT, $DEFAULT_TIMEOUT)',
       );
     },
+  );
+
+  test(
+    'should allow only address',
+    () {
+      // Setup - Arrange
+      final options = AddressCheckOptions(
+        address: InternetAddress('1.1.1.1'),
+      );
+
+      // Result - Assert
+      // Will pass if arguments are correct, as otherwise will have thrown
+      expect(true, equals(true));
+    }
+  );
+
+  test(
+    'should allow only hostname',
+    () {
+      // Setup - Arrange
+      final options = AddressCheckOptions(
+        hostname: 'google.com',
+      );
+
+      // Result - Assert
+      // Will pass if arguments are correct, as otherwise will have thrown
+      expect(true, equals(true));
+    }
+  );
+
+  test(
+    'should not allow no address or hostname',
+    () {
+      // Setup - Arrange
+      expect(() => AddressCheckOptions(), throwsA(isA<AssertionError>()));
+    }
+  );
+
+  test(
+    'should not allow both address and hostname',
+    () {
+      // Setup - Arrange
+      expect(() => AddressCheckOptions(
+        address: InternetAddress('1.1.1.1'),
+        hostname: 'google.com'
+      ), throwsA(isA<AssertionError>()));
+    }
   );
 }

--- a/test/address_check_result_test.dart
+++ b/test/address_check_result_test.dart
@@ -12,7 +12,7 @@ void main() {
       const int DEFAULT_PORT = 43;
       const bool isSuccess = true;
       final AddressCheckOptions tOptions = AddressCheckOptions(
-        tInternetAddress,
+        address: tInternetAddress,
         port: DEFAULT_PORT,
       );
 


### PR DESCRIPTION
## Status

**READY**

## Breaking Changes

**YES** (`AddressCheckOptions` constructor)

## Description

I wanted to use reachability of HTTP(S) for `www.msftncsi.com` as a means of checking connectivity, as it seems that in some rare cases, the DNS TCP connection may be blocked (see several issues mentioning getting `false` status even though they have a connection, and we have a client that has also experienced a similar issue).

The rationale for using a hostname is, that it is not guaranteed that the IP address where the HTTP service is hosted, is not going to change in the future (for DNS this isn't a concern, as the servers are expected to not change). Additionally, using a hostname also provides a DNS reachability test _for free_.

I've added a `hostname` field to `AddressCheckOptions` and extended the checking routine to include a lookup, if a hostname is provided. The positional argument `address` is now a named, optional argument.

Since the API has changed (for users that have already added custom addresses), this is a breaking change.

## Other comments

This PR only includes the hostname support, however I believe it would be useful to also include some well known HTTP servers in the default addresses list, in order to provide better compatibility out-of-the-box. I've chosen `www.msftncsi.com` for our app, as per the recommendation in https://superuser.com/a/769248.

Possibly additional documentation may be required before this can be considered shippable.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore