### PR TITLE
fix: replace unreliable default connectivity URLs with stable domains

### DIFF
--- a/lib/internet_connection_checker_constants.dart
+++ b/lib/internet_connection_checker_constants.dart
@@ -1,10 +1,9 @@
 part of 'internet_connection_checker.dart';
 
-// You can use [InternetConnectionCheckerConstants] like this:
-// ```dart
-// final DEFAULT_TIMEOUT = Constants.DEFAULT_TIMEOUT;
-// ```
-///
+/// You can use [InternetConnectionCheckerConstants] like this:
+/// ```dart
+/// final DEFAULT_TIMEOUT = Constants.DEFAULT_TIMEOUT;
+/// ```
 class InternetConnectionCheckerConstants {
   /// Default timeout duration (5 seconds) for checking connectivity.
   // ignore: constant_identifier_names
@@ -24,15 +23,15 @@ class InternetConnectionCheckerConstants {
 
   /// URL 1
   // ignore: constant_identifier_names
-  static const String URL_1 = 'https://dummyapi.online/api/movies/1';
+  static const String URL_1 = 'https://www.google.com';
 
   /// URL 2
   // ignore: constant_identifier_names
-  static const String URL_2 = 'https://jsonplaceholder.typicode.com/albums/1';
+  static const String URL_2 = 'https://www.bing.com';
 
   /// URL 3
   // ignore: constant_identifier_names
-  static const String URL_3 = 'https://fakestoreapi.com/products/1';
+  static const String URL_3 = 'https://www.amazon.com';
 
   /// Default list of addresses to check connectivity against.
   // ignore: non_constant_identifier_names


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description


This PR updates the default list of URLs used for connectivity checks in InternetConnectionCheckerConstants. The previous endpoints (dummyapi.online, jsonplaceholder.typicode.com, and fakestoreapi.com) are unreliable in some restricted or corporate networks due to content filtering or limited availability.

✅ Changes Made
Replaced the default connectivity URLs with more stable and globally accessible domains:

https://www.google.com

https://www.bing.com

https://www.amazon.com

Maintained use of constants (URL_1, URL_2, URL_3) for clean and consistent structure.

📈 Why This Is Needed
Many users reported connectivity check failures in production environments where the previous test URLs are blocked or not reachable. This update ensures:

More reliable internet detection across network types

Fewer false negatives in connectivity checks

📌 Impact
Improves the reliability of InternetConnectionChecker in restricted environments

No breaking changes — only internal default address behavior is updated

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
